### PR TITLE
Use diesel transaction when inserting new hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
   - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn
+  - sudo apt-get install -y -qq yarn=1.10.1-1
   - cd app
 install:
   - yarn install


### PR DESCRIPTION
When inserting a new paste into the db we first insert and then update the record to calculate the hash based on the id column. This has the possibility of failing during either the insert or update and if that were to happen the data would be left in an inconsistent state. Wrapping this in a transaction keeps the data integrity by rolling back any database operations if there is an error mid-transaction.

Only `create_paste` needs to have the transaction as right now it is the only function doing any data manipulation.